### PR TITLE
fix: Make flatbuffers library itself a go module.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/flatbuffers
+
+go 1.19

--- a/grpc/examples/generate.sh
+++ b/grpc/examples/generate.sh
@@ -26,9 +26,9 @@ cd ${current_dir}
 
 # Looks for flatc within the root dir & debug
 if [ -e ${main_dir}/flatc ]; then
-  alias fbc='${main_dir}/flatc'
+  fbc="${main_dir}/flatc"
 elif [ -e ${main_dir}/Debug/flatc ]; then
-  alias fbc='${main_dir}/Debug/flatc'
+  fbc="${main_dir}/Debug/flatc"
 else
   echo 'flatc' could not be found. Make sure to build FlatBuffers from the \
        $rootdir directory.
@@ -41,7 +41,7 @@ generator="--grpc $current_dir/greeter.fbs"
 cd go
 
 cd greeter
-fbc --bfbs-filenames ../.. --go ${generator}
+"$fbc" --bfbs-filenames ../.. --go ${generator}
 
 cd ${current_dir}
 
@@ -50,7 +50,7 @@ cd python
 
 cd greeter
 
-fbc --bfbs-filenames ../.. --python ${generator}
+"$fbc" --bfbs-filenames ../.. --python ${generator}
 
 cd ${current_dir}
 
@@ -58,7 +58,7 @@ cd ${current_dir}
 cd swift
 
 cd Greeter/Sources/Model
-fbc --bfbs-filenames ../../../.. --swift --gen-json-emit ${generator}
+"$fbc" --bfbs-filenames ../../../.. --swift --gen-json-emit ${generator}
 
 cd ${current_dir}
 
@@ -66,6 +66,6 @@ cd ${current_dir}
 cd ts
 
 cd greeter/src
-fbc --bfbs-filenames ../../.. --ts ${generator}
+"$fbc" --bfbs-filenames ../../.. --ts ${generator}
 
 cd ${current_dir}

--- a/grpc/examples/go/greeter/client/go.mod
+++ b/grpc/examples/go/greeter/client/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 replace github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0 => ../models
 
+replace github.com/google/flatbuffers => ../../../../..
+
 require (
 	github.com/google/flatbuffers v1.12.0
 	github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0

--- a/grpc/examples/go/greeter/models/go.mod
+++ b/grpc/examples/go/greeter/models/go.mod
@@ -2,6 +2,8 @@ module github.com/google/flatbuffers/grpc/examples/go/greeter/models
 
 go 1.15
 
+replace github.com/google/flatbuffers => ../../../../..
+
 require (
 	github.com/google/flatbuffers v1.12.0
 	google.golang.org/grpc v1.35.0

--- a/grpc/examples/go/greeter/server/go.mod
+++ b/grpc/examples/go/greeter/server/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 replace github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0 => ../models
 
+replace github.com/google/flatbuffers => ../../../../..
+
 require (
 	github.com/google/flatbuffers v1.12.0
 	github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0

--- a/grpc/tests/go.mod
+++ b/grpc/tests/go.mod
@@ -1,0 +1,22 @@
+module github.com/google/flatbuffers/grpc/tests
+
+replace github.com/google/flatbuffers => ../../
+
+replace github.com/google/flatbuffers/tests => ../../tests
+
+go 1.19
+
+require (
+	github.com/google/flatbuffers v0.0.0-00010101000000-000000000000
+	github.com/google/flatbuffers/tests v0.0.0-00010101000000-000000000000
+	google.golang.org/grpc v1.48.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -583,6 +583,7 @@ struct IDLOptions {
   bool binary_schema_gen_embed;
   std::string go_import;
   std::string go_namespace;
+  std::string go_namespace_module;
   bool protobuf_ascii_alike;
   bool size_prefixed;
   std::string root_type;

--- a/src/flatc.cpp
+++ b/src/flatc.cpp
@@ -147,6 +147,7 @@ const static FlatCOption options[] = {
     "Customize class suffix for C++ object-based API. Default Value is "
     "\"T\"." },
   { "", "go-namespace", "", "Generate the overriding namespace in Golang." },
+  { "", "go-namespace-module", "", "Generate imports of imported namespaces relative to this module." },
   { "", "go-import", "IMPORT",
     "Generate the overriding import for flatbuffers in Golang (default is "
     "\"github.com/google/flatbuffers/go\")." },
@@ -443,6 +444,9 @@ int FlatCompiler::Compile(int argc, const char **argv) {
       } else if (arg == "--go-namespace") {
         if (++argi >= argc) Error("missing golang namespace" + arg, true);
         opts.go_namespace = argv[argi];
+      } else if (arg == "--go-namespace-module") {
+        if (++argi >= argc) Error("missing golang namespace" + arg, true);
+        opts.go_namespace_module = argv[argi];
       } else if (arg == "--go-import") {
         if (++argi >= argc) Error("missing golang import" + arg, true);
         opts.go_import = argv[argi];

--- a/tests/GoTest.sh
+++ b/tests/GoTest.sh
@@ -16,35 +16,14 @@
 
 pushd "$(dirname $0)" >/dev/null
 test_dir="$(pwd)"
-go_path=${test_dir}/go_gen
-go_src=${go_path}/src
 
 # Emit Go code for the example schemas in the test dir:
-../flatc -g --gen-object-api -I include_test monster_test.fbs optional_scalars.fbs
-
-# Go requires a particular layout of files in order to link multiple packages.
-# Copy flatbuffer Go files to their own package directories to compile the
-# test binary:
-mkdir -p ${go_src}/MyGame/Example
-mkdir -p ${go_src}/MyGame/Example2
-mkdir -p ${go_src}/github.com/google/flatbuffers/go
-mkdir -p ${go_src}/flatbuffers_test
-mkdir -p ${go_src}/optional_scalars
-
-cp -a MyGame/*.go ./go_gen/src/MyGame/
-cp -a MyGame/Example/*.go ./go_gen/src/MyGame/Example/
-cp -a MyGame/Example2/*.go ./go_gen/src/MyGame/Example2/
-# do not compile the gRPC generated files, which are not tested by go_test.go
-# below, but have their own test.
-rm ./go_gen/src/MyGame/Example/*_grpc.go
-cp -a ../go/* ./go_gen/src/github.com/google/flatbuffers/go
-cp -a ./go_test.go ./go_gen/src/flatbuffers_test/
-cp -a optional_scalars/*.go ./go_gen/src/optional_scalars
-
-# https://stackoverflow.com/a/63545857/7024978
-# We need to turn off go modules for this script
-# to work.
-go env -w  GO111MODULE=off
+../flatc \
+  -g --gen-object-api \
+  -I include_test \
+  --go-namespace-module github.com/google/flatbuffers/tests \
+  monster_test.fbs \
+  optional_scalars.fbs
 
 # Run tests with necessary flags.
 # Developers may wish to see more detail by appending the verbosity flag
@@ -53,7 +32,7 @@ go env -w  GO111MODULE=off
 # Developers may also wish to run benchmarks, which may be achieved with the
 # flag -test.bench and the wildcard regexp ".":
 #   go -test -test.bench=. ...
-GOPATH=${go_path} go test flatbuffers_test \
+CGO_ENABLED=0 go test . \
                      --coverpkg=github.com/google/flatbuffers/go \
                      --cpp_data=${test_dir}/monsterdata_test.mon \
                      --out_data=${test_dir}/monsterdata_go_wire.mon \
@@ -64,7 +43,6 @@ GOPATH=${go_path} go test flatbuffers_test \
                      --fuzz_objects=10000
 
 GO_TEST_RESULT=$?
-rm -rf ${go_path}/{pkg,src}
 if [[ $GO_TEST_RESULT  == 0 ]]; then
     echo "OK: Go tests passed."
 else

--- a/tests/MyGame/Example/Any.go
+++ b/tests/MyGame/Example/Any.go
@@ -7,7 +7,7 @@ import (
 
 	flatbuffers "github.com/google/flatbuffers/go"
 
-	MyGame__Example2 "MyGame/Example2"
+	MyGame__Example2 "github.com/google/flatbuffers/tests/MyGame/Example2"
 )
 
 type Any byte

--- a/tests/MyGame/Example/AnyUniqueAliases.go
+++ b/tests/MyGame/Example/AnyUniqueAliases.go
@@ -7,7 +7,7 @@ import (
 
 	flatbuffers "github.com/google/flatbuffers/go"
 
-	MyGame__Example2 "MyGame/Example2"
+	MyGame__Example2 "github.com/google/flatbuffers/tests/MyGame/Example2"
 )
 
 type AnyUniqueAliases byte

--- a/tests/MyGame/Example/Monster.go
+++ b/tests/MyGame/Example/Monster.go
@@ -5,7 +5,7 @@ package Example
 import (
 	flatbuffers "github.com/google/flatbuffers/go"
 
-	MyGame "MyGame"
+	MyGame "github.com/google/flatbuffers/tests/MyGame"
 )
 
 /// an example documentation comment: "monster object"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,19 @@
+module github.com/google/flatbuffers/tests
+
+replace github.com/google/flatbuffers => ../
+
+go 1.19
+
+require (
+	github.com/google/flatbuffers v0.0.0-00010101000000-000000000000
+	google.golang.org/grpc v1.48.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)

--- a/tests/go_test.go
+++ b/tests/go_test.go
@@ -17,10 +17,10 @@
 package main
 
 import (
-	mygame "MyGame"          // refers to generated code
-	example "MyGame/Example" // refers to generated code
+	mygame "github.com/google/flatbuffers/tests/MyGame"          // refers to generated code
+	example "github.com/google/flatbuffers/tests/MyGame/Example" // refers to generated code
 	"encoding/json"
-	optional_scalars "optional_scalars" // refers to generated code
+	optional_scalars "github.com/google/flatbuffers/tests/optional_scalars" // refers to generated code
 
 	"bytes"
 	"flag"


### PR DESCRIPTION
Also involves converting tests/ to a go module. GoTest.sh can stop doing a
bunch of contortions in order to setup a GOPATH.

flatc gets a new option, --go-namespace-module, which is the import path to use
when importing a namespace for another imported message.