### PR TITLE
Use correct package versions for flatbuffers.

### DIFF
--- a/examples/go-echo/go.mod
+++ b/examples/go-echo/go.mod
@@ -2,6 +2,6 @@ module github.com/google/flatbuffers/examples/go-echo
 
 go 1.19
 
-require github.com/dolthub/flatbuffers/v23 v23.3.3
+require github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 
 replace github.com/dolthub/flatbuffers/v23 => ../../

--- a/grpc/examples/go/greeter/client/go.mod
+++ b/grpc/examples/go/greeter/client/go.mod
@@ -8,6 +8,6 @@ replace github.com/dolthub/flatbuffers/v23 => ../../../../..
 
 require (
 	github.com/google/flatbuffers/grpc/examples/go/greeter/models v0.0.0
-	github.com/dolthub/flatbuffers/v23 v23.3.3
+	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	google.golang.org/grpc v1.35.0
 )

--- a/grpc/examples/go/greeter/models/go.mod
+++ b/grpc/examples/go/greeter/models/go.mod
@@ -5,6 +5,6 @@ go 1.15
 replace github.com/dolthub/flatbuffers/v23 => ../../../../..
 
 require (
-	github.com/dolthub/flatbuffers/v23 v23.3.3
+	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	google.golang.org/grpc v1.35.0
 )

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,7 +5,7 @@ replace github.com/dolthub/flatbuffers/v23 => ../
 go 1.19
 
 require (
-	github.com/dolthub/flatbuffers/v23 v23.3.3
+	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	google.golang.org/grpc v1.48.0
 )
 


### PR DESCRIPTION
The current package version does not exist: https://pkg.go.dev/github.com/dolthub/flatbuffers/v23@v23.3.3

Updating to the correct version: https://pkg.go.dev/github.com/dolthub/flatbuffers/v23@v23.3.3-dh.2

The wrong version causes IDEs like GoLand to report an error when a project with these is loaded:
<img width="1053" alt="image" src="https://github.com/dolthub/flatbuffers/assets/1359724/c1fb3bef-b35b-46ae-b5d5-cfb9f5063933">
